### PR TITLE
Stabilize Q-DIN training with masked transitions and supervision

### DIFF
--- a/deterministic_rl_inference_snapshot/experiment_1_1_query_hierarchy.py
+++ b/deterministic_rl_inference_snapshot/experiment_1_1_query_hierarchy.py
@@ -15,7 +15,7 @@ def run_experiment_1_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
 
     # Train Q-DIN with inference-aware loss
     model = QDIN(env, hidden=128, K=5).to(device)
-    opt = torch.optim.Adam(model.parameters(), lr=2e-3)
+    opt = torch.optim.Adam(model.parameters(), lr=5e-4)
     w = LossWeights(td=0.1, inf=1.0, explic=0.05)
     mmp = MultiMetricProgression(env, V=gt['V'])
 
@@ -23,7 +23,7 @@ def run_experiment_1_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
     for ep in range(episodes):
         batch = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=24)
         loss, parts = inference_aware_loss(model, env, batch, gt, w)
-        opt.zero_grad(); loss.backward(); opt.step()
+        opt.zero_grad(); loss.backward(); torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0); opt.step()
         if (ep+1)%100==0:
             # eval on a held-out random batch
             test_q = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=40)


### PR DESCRIPTION
## Summary
- ensure default grid maps are solvable and evaluate rollouts with horizon tied to grid size
- restructure the Q-DIN planner to use masked transitions, differentiable reachability, and anchored model losses while softening reachability loss
- reduce Q-DIN learning rates, add gradient clipping, and tame output heads for more stable optimization

## Testing
- python -m compileall deterministic_rl_inference_snapshot

------
https://chatgpt.com/codex/tasks/task_e_68dbe70c66c8832996de2b30a71a0d3c