### PR TITLE
Implement curriculum-driven training and balanced loss weighting

### DIFF
--- a/deterministic_rl_inference_snapshot/experiment_1_1_query_hierarchy.py
+++ b/deterministic_rl_inference_snapshot/experiment_1_1_query_hierarchy.py
@@ -15,18 +15,21 @@ def run_experiment_1_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
 
     # Train Q-DIN with inference-aware loss
     model = QDIN(env, hidden=128, K=5).to(device)
-    opt = torch.optim.Adam(model.parameters(), lr=5e-4)
-    w = LossWeights(td=0.1, inf=1.0, explic=0.05)
+    w = LossWeights(td=0.1, inf=1.0, explic=0.05, model=0.25)
+    balancer = MultiTaskLossBalancer([k for k,v in w.as_dict().items() if v>0]).to(device)
+    params = list(model.parameters()) + list(balancer.parameters())
+    opt = torch.optim.Adam(params, lr=5e-4)
     mmp = MultiMetricProgression(env, V=gt['V'])
 
     tracker = ExperimentTracker()
     for ep in range(episodes):
-        batch = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=24)
-        loss, parts = inference_aware_loss(model, env, batch, gt, w)
+        phase, progress = curriculum_phase(ep, episodes)
+        batch = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=24, phase=phase, phase_progress=progress)
+        loss, parts = inference_aware_loss(model, env, batch, gt, w, balancer=balancer)
         opt.zero_grad(); loss.backward(); torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0); opt.step()
         if (ep+1)%100==0:
             # eval on a held-out random batch
-            test_q = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=40)
+            test_q = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=40, phase="full", phase_progress=1.0)
             metrics = evaluate_query_answering(model, env, test_q)
             tracker.log(ep=ep+1, loss=float(loss.item()), **metrics)
             print(f"[E1.1] ep={ep+1:4d} loss={loss.item():.3f} acc={metrics['acc']:.3f} meanIoU={metrics['set_mean_iou']:.3f}")

--- a/deterministic_rl_inference_snapshot/experiment_7_1_architecture_comparison.py
+++ b/deterministic_rl_inference_snapshot/experiment_7_1_architecture_comparison.py
@@ -15,17 +15,20 @@ def run_experiment_7_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
     # Train Q-DIN
     device='cuda' if torch.cuda.is_available() else 'cpu'
     qdin = QDIN(env).to(device)
-    opt = torch.optim.Adam(qdin.parameters(), lr=5e-4)
-    w = LossWeights(td=0.1, inf=1.0, explic=0.05)
+    w = LossWeights(td=0.1, inf=1.0, explic=0.05, model=0.25)
+    balancer = MultiTaskLossBalancer([k for k,v in w.as_dict().items() if v>0]).to(device)
+    params = list(qdin.parameters()) + list(balancer.parameters())
+    opt = torch.optim.Adam(params, lr=5e-4)
 
     tracker = ExperimentTracker()
     for ep in range(episodes):
-        batch = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=24)
-        loss, parts = inference_aware_loss(qdin, env, batch, gt, w)
+        phase, progress = curriculum_phase(ep, episodes)
+        batch = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=24, phase=phase, phase_progress=progress)
+        loss, parts = inference_aware_loss(qdin, env, batch, gt, w, balancer=balancer)
         opt.zero_grad(); loss.backward(); torch.nn.utils.clip_grad_norm_(qdin.parameters(), 1.0); opt.step()
         if (ep+1)%100==0:
             # evaluate
-            test_q = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=60)
+            test_q = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=60, phase="full", phase_progress=1.0)
             infm = evaluate_query_answering(qdin, env, test_q)
             # control: returns
             rew_qdin = rollouts_return(env, lambda s: int(torch.argmax(qdin({'type':'policy','s':s})['policy']).item()), n_episodes=20)


### PR DESCRIPTION
## Summary
- add structured state encoding, balanced comparative sampling, curriculum scheduling, and homoscedastic loss balancing to the helper utilities
- update experiments to consume the staged curriculum batches and shared loss balancer for consistent training across runs

## Testing
- python -m compileall deterministic_rl_inference_snapshot

------
https://chatgpt.com/codex/tasks/task_e_68dbf6229b508329ad6967c112d453d7