### PR TITLE
Stabilize loss scaling and add value magnitude unit test

### DIFF
--- a/deterministic_rl_inference_snapshot/experiment_1_1_query_hierarchy.py
+++ b/deterministic_rl_inference_snapshot/experiment_1_1_query_hierarchy.py
@@ -17,6 +17,7 @@ def run_experiment_1_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
     model = QDIN(env, hidden=128, K=5).to(device)
     w = LossWeights(td=0.1, inf=1.0, explic=0.05, model=0.25)
     balancer = MultiTaskLossBalancer([k for k,v in w.as_dict().items() if v>0]).to(device)
+    normalizer = LossNormalizer(['td','inf','explic','model'])
     params = list(model.parameters()) + list(balancer.parameters())
     opt = torch.optim.Adam(params, lr=5e-4)
     mmp = MultiMetricProgression(env, V=gt['V'])
@@ -25,14 +26,30 @@ def run_experiment_1_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
     for ep in range(episodes):
         phase, progress = curriculum_phase(ep, episodes)
         batch = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=24, phase=phase, phase_progress=progress)
-        loss, parts = inference_aware_loss(model, env, batch, gt, w, balancer=balancer)
-        log_payload = {k: parts[k] for k in parts if k.startswith('loss_') or k.startswith('count_')}
+        loss, parts = inference_aware_loss(
+            model,
+            env,
+            batch,
+            gt,
+            w,
+            balancer=balancer,
+            normalizer=normalizer,
+            normalize_rewards=True,
+        )
+        log_payload = {
+            k: parts[k]
+            for k in parts
+            if k.startswith(('loss_', 'count_', 'ema_', 'norm_', 'weighted_'))
+        }
         log_payload['entropy'] = parts.get('entropy', 0.0)
         log_event("EPOCH_LOSS", epoch=ep + 1, **log_payload)
         if loss is None:
             log_event("SKIP_UPDATE_NON_FINITE", epoch=ep + 1)
             continue
-        opt.zero_grad(); loss.backward(); torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0); opt.step()
+        opt.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(params, 1.0)
+        opt.step()
         if (ep+1)%100==0:
             # eval on a held-out random batch
             test_q = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=40, phase="full", phase_progress=1.0)

--- a/deterministic_rl_inference_snapshot/test.py
+++ b/deterministic_rl_inference_snapshot/test.py
@@ -5,6 +5,7 @@
 from experiment_1_1_query_hierarchy import run_experiment_1_1
 from experiment_2_1_learning_objectives import run_experiment_2_1
 from experiment_7_1_architecture_comparison import run_experiment_7_1
+from helper import unit_test_value_scaling
 
 print("Running E1.1 ...")
 out1 = run_experiment_1_1(episodes=200)
@@ -12,5 +13,8 @@ print("Running E2.1 ...")
 out2 = run_experiment_2_1(episodes=200)
 print("Running E7.1 ...")
 out3 = run_experiment_7_1(episodes=200)
+print("Running value scaling unit test ...")
+scale_metrics = unit_test_value_scaling()
+print("Value scaling errors:", scale_metrics)
 
 print("Done.")


### PR DESCRIPTION
## Summary
- normalize inference-aware losses by ground-truth magnitudes and a per-head EMA normalizer
- apply global gradient clipping and expose normalized loss metrics during experiment logging
- add a deterministic 5x5 value/Q unit test to validate analytic scaling

## Testing
- `python test.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e0102822788329bffcde455c4e09a1