### PR TITLE
Improve Q-value stability and evaluation masking

### DIFF
--- a/deterministic_rl_inference_snapshot/experiment_7_1_architecture_comparison.py
+++ b/deterministic_rl_inference_snapshot/experiment_7_1_architecture_comparison.py
@@ -18,6 +18,11 @@ def run_experiment_7_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
     w = LossWeights(td=0.1, inf=1.0, explic=0.05, model=0.25)
     balancer = MultiTaskLossBalancer([k for k,v in w.as_dict().items() if v>0]).to(device)
     normalizer = LossNormalizer(['td','inf','explic','model'])
+    target_model = QDIN(env).to(device)
+    target_model.load_state_dict(qdin.state_dict())
+    target_model.eval()
+    tau = 0.01
+
     params = list(qdin.parameters()) + list(balancer.parameters())
     opt = torch.optim.Adam(params, lr=5e-4)
 
@@ -34,6 +39,9 @@ def run_experiment_7_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
             balancer=balancer,
             normalizer=normalizer,
             normalize_rewards=True,
+            target_model=target_model,
+            gamma=0.99,
+            td_target_clip=10.0,
         )
         log_payload = {
             k: parts[k]
@@ -49,6 +57,9 @@ def run_experiment_7_1(grid_size=8, n_obstacles=8, episodes=600, seed=0):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(params, 1.0)
         opt.step()
+        with torch.no_grad():
+            for tgt_param, src_param in zip(target_model.parameters(), qdin.parameters()):
+                tgt_param.data.lerp_(src_param.data, tau)
         if (ep+1)%100==0:
             # evaluate
             test_q = select_queries_active_coverage(env, mmp, (gt['V'],gt['Q']), batch_size=60, phase="full", phase_progress=1.0)


### PR DESCRIPTION
## Summary
- add dueling/double-DQN updates, target-network soft updates, and normalized TD targets for the baseline Q learners
- integrate target networks into all Q-DIN training scripts, log per-head loss variance, and report TD target statistics
- mask invalid actions during evaluation rollouts to prevent self-loops from dominating horizons

## Testing
- python deterministic_rl_inference_snapshot/test.py *(fails: missing PyTorch runtime in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1265041ac83298d131c166a197ca5